### PR TITLE
Add support for manually setting a model to staging status

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,10 +21,10 @@ const getModelStatus = async (model: InferenceModel) => {
 // Get Replicate model warm/cold statuses in parallel
 const statuses = await Promise.all(inferenceModels.map(getModelStatus));
 
-// Add status to each model object
+// Set status (unless it's already manually defined on the model object)
 const replicateModels = inferenceModels.map((model, index) => ({
     ...model,
-    status: statuses[index],
+    status: model.status ?? statuses[index],
 }));
 
 console.log("\n\nReplicate model mappings:");

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,6 +2,9 @@ export interface InferenceModel {
     hfModel: string;
     providerModel: string;
     task: string;
+
+    // You can set this to force the value, e.g. to keep a model as 'staging' even if it's
+    // warm/live on Replicate. If not set, the status will be inferred from the provider model
     status?: 'live' | 'staging';
 }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -13,6 +13,7 @@ export const inferenceModels: InferenceModel[] = [
         hfModel: "deepseek-ai/DeepSeek-R1",
         providerModel: "deepseek-ai/deepseek-r1",
         task: "conversational",
+        status: "staging",
     },
     {
         hfModel: "black-forest-labs/FLUX.1-dev",


### PR DESCRIPTION
This PR does two things:

- Adds support for manually setting a model status to `staging`, for cases where we want to test models on HF, even if we know they're always warm/ready/live.
- Updates the [deepseek-ai/DeepSeek-R1](https://github.com/deepseek-ai/DeepSeek-R1) status to staging for now, since it's not currently working on HF, pending an OpenAPI-compatible conversational interface on the Replicate model.

Resolves #2 

cc @Wauplin @sbrandeis