### PR TITLE
disable Lightricks/LTX-Video mapping

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -90,9 +90,9 @@ export const inferenceModels: InferenceModel[] = [
         providerModel: "wan-video/wan-2.1-1.3b",
         task: "text-to-video",
     },
-    {
-        hfModel: "Lightricks/LTX-Video",
-        providerModel: "lightricks/ltx-video:8c47da666861d081eeb4d1261853087de23923a268a69b63febdf5dc1dee08e4",
-        task: "text-to-video",
-    },
+    // {
+    //     hfModel: "Lightricks/LTX-Video",
+    //     providerModel: "lightricks/ltx-video:8c47da666861d081eeb4d1261853087de23923a268a69b63febdf5dc1dee08e4",
+    //     task: "image-to-video",
+    // },
 ];


### PR DESCRIPTION
This PR comments out the mapping for https://huggingface.co/Lightricks/LTX-Video

This model mapping used to work, but the [Actions workflow to sync](https://github.com/replicate/huggingface-model-mappings/actions/runs/13683560572/job/38261514344#step:5:131) recently started failing with this message:

```
Request error: Error: Request failed: 400 Bad Request - {"error":"The HF model pipeline_tag does not match the provided task: image-to-video != text-to-video"}
```

I'm guessing the model used to be classified as text-to-image on HF, but then was reclassified as `image-to-video`?

Technically this model can be used as either text-to-video or image-to-video. Not sure how one task type wins out over another, or if models can be categorized with multiple task types?

cc @Wauplin @SBrandeis does this make sense?
