### PR TITLE
Adds a mapping for `stepfun-ai/Step1X-Edit`.

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -105,4 +105,9 @@ export const inferenceModels: InferenceModel[] = [
         providerModel: "tarot-cards/rider-waite:6d77a07ef88e8a09389385cb14d98b12629a4b23b0537b01dfeb833c32827546",
         task: "text-to-image",
     },
+    {
+        hfModel: "stepfun-ai/Step1X-Edit",
+        providerModel: "zsxkib/step1x-edit",
+        task: "image-to-image",
+    },
 ];


### PR DESCRIPTION
Adds a mapping for `stepfun-ai/Step1X-Edit`.

This connects the Hugging Face model page to the `zsxkib/step1x-edit` model on Replicate. Now, people can run the model on Replicate directly from the `stepfun-ai/Step1X-Edit` page on Hugging Face.

**Details:**

*   Hugging Face model: `stepfun-ai/Step1X-Edit`
*   Replicate model: `zsxkib/step1x-edit`
*   Task: `image-to-image`

This follows the steps in `README.md`.