### PR TITLE
add script to delete mappings by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ npm run list-provider-mappings -- replicate
 
 This will output a JSON object containing all model mappings for the specified provider, organized by task type.
 
+### Delete a Mapping
+
+To delete a specific model mapping:
+
+```bash
+npm run delete-mapping -- <mapping-id>
+```
+
+For example:
+```bash
+npm run delete-mapping -- "namespace/model-name"
+```
+
+This will permanently delete the specified mapping from Hugging Face. Use with caution!
+
 Note: You'll need to set the `HF_TOKEN` environment variable to use these scripts:
 ```bash
 export HF_TOKEN=<your-huggingface-token>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "list-providers": "tsx script/list-providers.ts",
-    "list-provider-mappings": "tsx script/list-provider-mappings.ts"
+    "list-provider-mappings": "tsx script/list-provider-mappings.ts",
+    "delete-mapping": "tsx script/delete-mapping.ts"
   },
   "dependencies": {
     "@huggingface/inference": "^2.6.4",

--- a/script/delete-mapping.ts
+++ b/script/delete-mapping.ts
@@ -1,0 +1,24 @@
+import HFInferenceProviderClient from '../src/hf.js';
+
+const mappingId = process.argv[2];
+
+if (!mappingId) {
+    console.error('Please provide a mapping ID as an argument');
+    console.error('Usage: npm run delete-mapping -- <mapping-id>');
+    process.exit(1);
+}
+
+const hf = new HFInferenceProviderClient();
+
+const deleteMapping = async () => {
+    console.log(`\nDeleting mapping: ${mappingId}`);
+    try {
+        await hf.deleteMappingItem(mappingId);
+        console.log('Successfully deleted mapping');
+    } catch (error) {
+        console.error(`Error deleting mapping ${mappingId}:`, error);
+        process.exit(1);
+    }
+};
+
+await deleteMapping(); 


### PR DESCRIPTION
For cases where we mis-register a model or a tag-filter.