### PR TITLE
set Step1X-Edit to staging status

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -109,5 +109,6 @@ export const inferenceModels: InferenceModel[] = [
         hfModel: "stepfun-ai/Step1X-Edit",
         providerModel: "zsxkib/step1x-edit",
         task: "image-to-image",
+        status: "staging",
     },
 ];


### PR DESCRIPTION
image-to-image support is not ready in the inference client yet, so let's disable it manually here for now.

Working on support here: https://github.com/huggingface/huggingface.js/pull/1427

cc @zsxkib FYI -- we can turn it back on once the PR above lands.

