### PR TITLE
feat: update to new HuggingFace model mapping API endpoints

### DIFF
--- a/src/hf.ts
+++ b/src/hf.ts
@@ -17,7 +17,7 @@ interface TagFilterMappingItem {
 type MappingItem = ModelMappingItem | TagFilterMappingItem;
 
 interface StatusUpdateRequest {
-  hfModel: string;
+  mappingId: string;
   status: 'live' | 'staging';
 }
 
@@ -96,14 +96,14 @@ class HFInferenceProviderClient {
   }
 
   async updateMappingItemStatus(statusUpdate: StatusUpdateRequest): Promise<MappingItem> {
-    const url = `${this.baseUrl}/api/partners/${this.provider}/models/status`;
+    const url = `${this.baseUrl}/api/partners/${this.provider}/models/${statusUpdate.mappingId}/status`;
 
     return this.request<MappingItem>(url, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify(statusUpdate),
+      body: JSON.stringify({ status: statusUpdate.status }),
     });
   }
   


### PR DESCRIPTION
## Summary
- Updates deprecated `PUT /api/partners/{provider}/models/status` to new `PUT /api/partners/{provider}/models/{mappingId}/status` endpoint
- Changes `StatusUpdateRequest` interface to use `mappingId` instead of `hfModel`
- Prepares for deprecation of old endpoints scheduled for next week

## Breaking Changes
- `updateMappingItemStatus()` now requires `mappingId` instead of `hfModel` in request object

🤖 Generated with [Claude Code](https://claude.ai/code)