### PR TITLE
ci: enable npm caching in GitHub Actions workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: npm
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

- Add npm caching to actions/setup-node step

## Benefits

This will speed up CI runs by caching node_modules between workflow runs, reducing install times and improving developer experience.

## Test plan

- [x] Verified workflow syntax is valid
- [ ] CI workflows will run faster on subsequent runs after this merge